### PR TITLE
bug fix for checking bounds for ints and longs

### DIFF
--- a/agent/session/contracts/agentmessage.go
+++ b/agent/session/contracts/agentmessage.go
@@ -150,11 +150,15 @@ func (agentMessage *AgentMessage) Deserialize(log logger.T, input []byte) (err e
 	}
 
 	agentMessage.PayloadLength, err = getUInteger(log, input, AgentMessage_PayloadLengthOffset)
+	if err != nil {
+		log.Errorf("Could not deserialize field PayloadLength with error: %v", err)
+		return err
+	}
 
 	headerLength, herr := getUInteger(log, input, AgentMessage_HLOffset)
 	if herr != nil {
-		log.Errorf("Could not deserialize field HeaderLength with error: %v", err)
-		return err
+		log.Errorf("Could not deserialize field HeaderLength with error: %v", herr)
+		return herr
 	}
 
 	agentMessage.HeaderLength = headerLength
@@ -521,7 +525,7 @@ func putULong(log logger.T, byteArray []byte, offset int, value uint64) (err err
 // getLong gets a long integer value from a byte array starting from the specified offset. 64 bit.
 func getLong(log logger.T, byteArray []byte, offset int) (result int64, err error) {
 	byteArrayLength := len(byteArray)
-	if offset > byteArrayLength-1 || offset+8 > byteArrayLength-1 || offset < 0 {
+	if offset > byteArrayLength-1 || offset+8-1 > byteArrayLength-1 || offset < 0 {
 		log.Error("getLong failed: Offset is invalid.")
 		return 0, errors.New("Offset is outside the byte array.")
 	}
@@ -531,7 +535,7 @@ func getLong(log logger.T, byteArray []byte, offset int) (result int64, err erro
 // putLong puts a long integer value to a byte array starting from the specified offset.
 func putLong(log logger.T, byteArray []byte, offset int, value int64) (err error) {
 	byteArrayLength := len(byteArray)
-	if offset > byteArrayLength-1 || offset+8 > byteArrayLength-1 || offset < 0 {
+	if offset > byteArrayLength-1 || offset+8-1 > byteArrayLength-1 || offset < 0 {
 		log.Error("putLong failed: Offset is invalid.")
 		return errors.New("Offset is outside the byte array.")
 	}
@@ -549,7 +553,7 @@ func putLong(log logger.T, byteArray []byte, offset int, value int64) (err error
 // getInteger gets an integer value from a byte array starting from the specified offset.
 func getInteger(log logger.T, byteArray []byte, offset int) (result int32, err error) {
 	byteArrayLength := len(byteArray)
-	if offset > byteArrayLength-1 || offset+4 > byteArrayLength-1 || offset < 0 {
+	if offset > byteArrayLength-1 || offset+4-1 > byteArrayLength-1 || offset < 0 {
 		log.Error("getInteger failed: Offset is invalid.")
 		return 0, errors.New("Offset is bigger than the byte array.")
 	}
@@ -559,7 +563,7 @@ func getInteger(log logger.T, byteArray []byte, offset int) (result int32, err e
 // putInteger puts an integer value to a byte array starting from the specified offset.
 func putInteger(log logger.T, byteArray []byte, offset int, value int32) (err error) {
 	byteArrayLength := len(byteArray)
-	if offset > byteArrayLength-1 || offset+4 > byteArrayLength-1 || offset < 0 {
+	if offset > byteArrayLength-1 || offset+4-1 > byteArrayLength-1 || offset < 0 {
 		log.Error("putInteger failed: Offset is invalid.")
 		return errors.New("Offset is outside the byte array.")
 	}

--- a/agent/session/contracts/agentmessage_test.go
+++ b/agent/session/contracts/agentmessage_test.go
@@ -56,8 +56,13 @@ func TestGetInteger(t *testing.T) {
 	assert.Equal(t, int32(256), result)
 	assert.Nil(t, err)
 
-	input = []byte{0x00, 0x00, 0x00, 0x00, 0xFF, 0x00}
+	input = []byte{0x00, 0x00, 0x00, 0x00, 0x01, 0x00}
 	result, err = getInteger(log.NewMockLog(), input, 2)
+	assert.Equal(t, int32(256), result)
+	assert.Nil(t, err)
+
+	input = []byte{0x00, 0x00, 0x00, 0x00, 0xFF, 0x00}
+	result, err = getInteger(log.NewMockLog(), input, 3)
 	assert.Equal(t, int32(0), result)
 	assert.NotNil(t, err)
 }


### PR DESCRIPTION
## *Issue #, if available:*
None

## *Description of changes:*

### Fixing Bounds Checking Logic
There is a small bug in the AgentMessage.  As exampled below, when checking bounds on integers and longs, the code checks the upper bound incorrectly.  Instead of checking whether there is enough room in the `byteArray` to read an integer, it is one off, and will throw an error if there are any less than 5 bytes remaining (`offset+4 > byteArrayLength-1`).  I believe that the intended functionality was to make sure that `byteArray[offset:offset+4]` can execute without throwing an error and not to ensure that there is always a single-byte buffer at the end of the array.

```golang
func getInteger(log logger.T, byteArray []byte, offset int) (result int32, err error) {
	byteArrayLength := len(byteArray)
	if offset > byteArrayLength-1 || offset+4 > byteArrayLength-1 || offset < 0 {
		log.Error("getInteger failed: Offset is invalid.")
		return 0, errors.New("Offset is bigger than the byte array.")
	}
	return bytesToInteger(log, byteArray[offset:offset+4])
}
```

Since the second argument in the slice is exclusive, `byteArray[offset:offset+4]` only reads the literal bytes from `offset` to `offset+4-1`.  Therefore, `offset+4-1` must be `<= byteArrayLength` or, must not be `offset+4-1 > byteArrayLength`.  This is logic is used in most other upper bound checks in the AgentMessage code, except for Integers and Longs.  

### Testing Fixes
I ended up only need to change a single test and added one to test the correct bounds:

```golang
input = []byte{0x00, 0x00, 0x00, 0x00, 0xFF, 0x00}
result, err = getInteger(log.NewMockLog(), input, 2)
assert.Equal(t, int32(0), result)
assert.NotNil(t, err)
```

The above test should not result in an error, if you took `input[2:2+4]` you would get a valid integer.  Therefore, I changed this to `assert.Nil(t, err)`.  Secondly, I added a test to check the actual bounds:

```golang
input = []byte{0x00, 0x00, 0x00, 0x00, 0xFF, 0x00}
result, err = getInteger(log.NewMockLog(), input, 3)
assert.Equal(t, int32(0), result)
assert.NotNil(t, err)
```
This test does describe a situation where there are not enough bytes to read a full integer.  `input[3:3+4]` would result in a panic.

### Fixing Error Handling in Dezerialize
Perhaps this was a deliberate decision at the time, but the original code below shows a lack of error checking for the PayloadLength.  I thought that there should be error reporting for PayloadLength, like there is for every other component.  Then, the header error is conditioned on `herr != nil` yet prints and returns an `err` message instead.  So, I changed the `err`s to `herr`s in that if statement.

```golang
agentMessage.PayloadLength, err = getUInteger(log, input, AgentMessage_PayloadLengthOffset)

headerLength, herr := getUInteger(log, input, AgentMessage_HLOffset)
if herr != nil {
	log.Errorf("Could not deserialize field HeaderLength with error: %v", err)
	return err
}
```
_________________
*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
